### PR TITLE
Fixed github link in template header menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@ The above copyright notice and this permission notice shall be included in all c
             </a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" rel="tooltip" title="Star on GitHub" data-placement="bottom" href="https://www.github.com/CreativeTimOfficial/paper-kit" target="_blank">
+            <a class="nav-link" rel="tooltip" title="Star on GitHub" data-placement="bottom" href="https://www.github.com/CreativeTimOfficial/paper-kit-2" target="_blank">
               <i class="fa fa-github"></i>
               <p class="d-lg-none">GitHub</p>
             </a>


### PR DESCRIPTION
It was pointing to project `paper-kit` instead of `paper-kit-2`